### PR TITLE
download all updated packages after repo update

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -26,6 +26,7 @@ type Cache struct {
 	repoDownloads map[database.Repository]struct{}
 	mu            sync.Mutex
 	repoMu        sync.Mutex
+	bgDownload    sync.Mutex
 }
 
 // ReadSeekCloser implements io.ReadSeeker and io.Closer

--- a/cache/download.go
+++ b/cache/download.go
@@ -124,6 +124,9 @@ func (c *Cache) startDownload(d *download) (*ongoingDownload, error) {
 	return nil, errors.New("Packet could not be downloaded from any mirror")
 }
 
+// Asynchronous callback for a finished download
+// The function will rename the .part file to the original file and register it
+// in the cache registry.
 func (c *Cache) finalizeDownload(dl *ongoingDownload, err error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -156,6 +159,8 @@ func (c *Cache) finalizeDownload(dl *ongoingDownload, err error) {
 	dl.Dl.Callback(nil)
 }
 
+// backgroundDownload will start the given download in the background.
+// Only one background download will be active at a given time
 func (c *Cache) backgroundDownload(dl *download) error {
 	c.bgDownload.Lock()
 	defer c.bgDownload.Unlock()
@@ -192,6 +197,8 @@ func (c *Cache) backgroundDownload(dl *download) error {
 	return nil
 }
 
+// countWriter wraps a writer. The total number of bytes written will be appended to *Written
+// in an atomic manner.
 type countWriter struct {
 	W       io.Writer
 	Written *int64

--- a/database/repository.go
+++ b/database/repository.go
@@ -6,6 +6,7 @@ import (
 	"compress/gzip"
 	"io"
 	"os"
+	"path/filepath"
 
 	"github.com/pkg/errors"
 	"github.com/veecue/pacman-smartmirror/packet"
@@ -51,7 +52,7 @@ func ParseDB(r io.Reader, cb func(*packet.Packet)) error {
 	}
 	defer zr.Close()
 
-	return ParseDBGUnzipped(r, cb)
+	return ParseDBGUnzipped(zr, cb)
 }
 
 // ParseDBSlice reads a pacman .db file and creates a []packet.Packet
@@ -88,9 +89,12 @@ func ParseDBGUnzipped(r io.Reader, cb func(*packet.Packet)) error {
 			return nil
 		}
 		if err != nil {
-			return errors.New("Error while reading tar (DbScratch)")
+			return errors.Wrap(err, "Error while reading tar")
 		}
 		if pkg.FileInfo().IsDir() {
+			continue
+		}
+		if _, name := filepath.Split(pkg.Name); name != "desc" {
 			continue
 		}
 		io.Copy(buf, reader)


### PR DESCRIPTION
This way, packages will always be ready on the smartmirror, when a
client wants to do updates.

Closes: #3