### PR TITLE
store packages by arch and repo

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -2,9 +2,8 @@ package cache
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -20,7 +19,7 @@ import (
 type Cache struct {
 	directory     string
 	mirrors       mirrorlist.Mirrorlist
-	packets       packet.Set
+	packets       map[database.Repository]packet.Set
 	downloads     map[string]*ongoingDownload
 	repos         map[database.Repository]struct{}
 	repoDownloads map[database.Repository]struct{}
@@ -35,58 +34,102 @@ type ReadSeekCloser interface {
 	io.Closer
 }
 
-func (c *Cache) initPackets() error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	files, err := ioutil.ReadDir(c.directory)
-	if err != nil {
-		return errors.Wrap(err, "Error opening cache dir")
-	}
-
-	for _, file := range files {
-		if file.IsDir() {
-			continue
-		}
-
-		if strings.HasSuffix(file.Name(), ".part") {
-			os.Remove(path.Join(c.directory, file.Name()))
-			continue
-		}
-
-		p, err := packet.FromFilename(file.Name())
-		if err != nil {
-			return errors.Wrapf(err, "Invalid packet in directory")
-		}
-
-		c.packets.Insert(p)
-	}
-
-	return nil
-}
-
 // New creates a new cache from a given directory
 func New(directory string, mirrors mirrorlist.Mirrorlist) (*Cache, error) {
 	c := &Cache{
 		directory:     directory,
-		packets:       make(packet.Set),
+		packets:       make(map[database.Repository]packet.Set),
 		mirrors:       mirrors,
 		downloads:     make(map[string]*ongoingDownload),
 		repos:         make(map[database.Repository]struct{}),
 		repoDownloads: make(map[database.Repository]struct{}),
 	}
 
-	err := c.initPackets()
-	if err != nil {
-		return nil, err
-	}
-
-	err = c.initRepos()
+	err := c.init()
 	if err != nil {
 		return nil, err
 	}
 
 	return c, nil
+}
+
+// init scans the cache directory and inits the packet and database caches accordingly
+func (c *Cache) init() error {
+	// Migrate packages stored directly in the dir to their proper repo location
+	migrationList := make([]*packet.Packet, 0)
+
+	err := filepath.Walk(c.directory, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		rel, err := filepath.Rel(c.directory, path)
+		if err != nil {
+			return err
+		}
+
+		if strings.HasSuffix(rel, ".part") {
+			return os.Remove(path)
+		}
+
+		parts := strings.Split(rel, string(filepath.Separator))
+
+		if len(parts) == 1 {
+			filename := parts[0]
+			p, err := packet.FromFilename(filename)
+			if err != nil {
+				return errors.Wrapf(err, "Invalid packet in directory")
+			}
+
+			migrationList = append(migrationList, p)
+		}
+
+		if len(parts) == 2 {
+			arch := parts[0]
+			db := parts[1]
+
+			if !strings.HasSuffix(db, ".db") {
+				return nil
+			}
+
+			c.repos[database.Repository{
+				Name: strings.TrimSuffix(db, ".db"),
+				Arch: arch,
+			}] = struct{}{}
+			return err
+		}
+
+		if len(parts) == 3 {
+			filename := parts[2]
+			p, err := packet.FromFilename(filename)
+			if err != nil {
+				return errors.Wrapf(err, "Invalid packet in directory")
+			}
+
+			repo := database.Repository{
+				Arch: parts[0],
+				Name: parts[1],
+			}
+
+			if _, ok := c.packets[repo]; !ok {
+				c.packets[repo] = make(packet.Set)
+			}
+
+			c.packets[repo].Insert(p)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return errors.Wrap(err, "Error reading cache directory")
+	}
+
+	return errors.Wrap(c.migrate(migrationList), "Error migrating")
 }
 
 // GetPacket serves a packet either from the cache or proxies it from a mirror
@@ -99,13 +142,13 @@ func (c *Cache) GetPacket(p *packet.Packet, repo *database.Repository) (ReadSeek
 	go c.addRepo(repo, nil)
 
 	// First: check if the packet is currently being downloaded
-	if download, ok := c.downloads[p.Filename()]; ok && download.Dl.P == *p {
+	if download, ok := c.downloads[(&download{P: *p, R: *repo}).Path()]; ok && download.Dl.P == *p {
 		return download.GetReader()
 	}
 
 	// Second: check if the packet already is available in cache
-	if cachedP := c.packets.ByFilename(p.Filename()); cachedP != nil {
-		f, err := os.Open(path.Join(c.directory, cachedP.Filename()))
+	if cachedP := c.packets[*repo].ByFilename(p.Filename()); cachedP != nil {
+		f, err := os.Open(filepath.Join(c.directory, repo.Arch, repo.Name, cachedP.Filename()))
 		if err != nil {
 			return nil, errors.Wrap(err, "Error opening cached packet file")
 		}
@@ -114,7 +157,7 @@ func (c *Cache) GetPacket(p *packet.Packet, repo *database.Repository) (ReadSeek
 	}
 
 	// Bail out if newer package version exists
-	for _, cachedP := range c.packets.FindOtherVersions(p) {
+	for _, cachedP := range c.packets[*repo].FindOtherVersions(p) {
 		versionDiff := packet.CompareVersions(p.Version, cachedP.Version)
 		if versionDiff < 0 {
 			return nil, errors.New("Newer version available")

--- a/cache/migrate.go
+++ b/cache/migrate.go
@@ -1,0 +1,107 @@
+package cache
+
+import (
+	"bufio"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/pkg/errors"
+	"github.com/veecue/pacman-smartmirror/database"
+	"github.com/veecue/pacman-smartmirror/packet"
+)
+
+func (c *Cache) migrate(toMigrate []*packet.Packet) error {
+	if len(toMigrate) > 0 {
+		log.Println("Starting migration of", len(toMigrate), "packages...")
+	}
+	sizes := make(map[packet.Packet]string)
+	for _, p := range toMigrate {
+		fi, err := os.Stat(filepath.Join(c.directory, p.Filename()))
+		if err != nil {
+			return errors.Wrapf(err, "Error stating %s", p.Filename())
+		}
+		sizes[*p] = strconv.FormatInt(fi.Size(), 10)
+	}
+
+	type hasRepo struct {
+		R database.Repository
+		B bool
+	}
+	cache := make(map[packet.Packet]*hasRepo)
+	for repo := range c.repos {
+		err := database.ParseDBFromFile(filepath.Join(c.directory, repo.Arch, repo.Name+".db"),
+			func(p *packet.Packet, r io.Reader) {
+				size, ok := sizes[*p]
+				if !ok {
+					return
+				}
+				br := bufio.NewReader(r)
+				for {
+					line, err := br.ReadString('\n')
+					if err != nil {
+						break
+					}
+					if line == "%CSIZE%\n" {
+						line, err = br.ReadString('\n')
+						if err != nil {
+							break
+						}
+						if line == size+"\n" {
+							// Found candidate
+							if cached, ok := cache[*p]; ok {
+								// Double match, discarding
+								cached.B = false
+								log.Printf("Double match for %s: found in %s and %s with size %s",
+									p.Filename(), cached.R, repo, size)
+								break
+							}
+							cache[*p] = &hasRepo{
+								R: repo,
+								B: true,
+							}
+						}
+						break
+					}
+				}
+			})
+		if err != nil {
+			return errors.Wrapf(err, "Error opening %s", filepath.Join(repo.Arch, repo.Name+".db"))
+		}
+	}
+
+	for p, has := range cache {
+		delete(sizes, p)
+		if has.B {
+			err := os.MkdirAll(filepath.Join(c.directory, has.R.Arch, has.R.Name), 0755)
+			if err != nil {
+				return errors.Wrapf(err, "Error creating %s", filepath.Join(has.R.Arch, has.R.Name))
+			}
+
+			err = os.Rename(
+				filepath.Join(c.directory, p.Filename()),
+				filepath.Join(c.directory, has.R.Arch, has.R.Name, p.Filename()))
+
+			if err != nil {
+				return errors.Wrapf(err, "Error moving %s", p.Filename())
+			}
+
+			c.mu.Lock()
+			if _, ok := c.packets[has.R]; !ok {
+				c.packets[has.R] = make(packet.Set)
+			}
+
+			c.packets[has.R].Insert(&p)
+			c.mu.Unlock()
+		}
+	}
+
+	for p := range sizes {
+		log.Println("No match found for", p.Filename())
+	}
+
+	log.Println("Migration done")
+	return nil
+}

--- a/server/server.go
+++ b/server/server.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"log"
 	"net/http"
 	"strings"
 	"time"
@@ -79,6 +80,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	reader, err := s.packetCache.GetPacket(p, repo)
 	if err != nil {
+		log.Println("Error serving", p.Filename(), err)
 		http.NotFound(w, r)
 		return
 	}


### PR DESCRIPTION
This way, packages with the same name (especially "any" packages) can be
stored together in one pacman-smartmirror instance.

Fixes: #23